### PR TITLE
Add ICounterDevice interface and EncoderMode enum

### DIFF
--- a/ControlBeeAbstract/Constants/EncoderMode.cs
+++ b/ControlBeeAbstract/Constants/EncoderMode.cs
@@ -1,0 +1,9 @@
+namespace ControlBeeAbstract.Constants;
+
+public enum EncoderMode : uint
+{
+    UpDown = 0x00,
+    AbPhase1x = 0x01,
+    AbPhase2x = 0x02,
+    AbPhase4x = 0x03,
+}

--- a/ControlBeeAbstract/Devices/ICounterDevice.cs
+++ b/ControlBeeAbstract/Devices/ICounterDevice.cs
@@ -1,0 +1,10 @@
+using ControlBeeAbstract.Constants;
+
+namespace ControlBeeAbstract.Devices;
+
+public interface ICounterDevice : IDevice
+{
+    void SetEncoderMode(int channel, EncoderMode mode);
+    void SetCounterValue(int channel, double value);
+    double GetCounterValue(int channel);
+}


### PR DESCRIPTION
# [What]
Add ICounterDevice interface and EncoderMode enum

# [Why]
Counter 하드웨어를 추상화하여 다양한 드라이버에서 공통으로 사용할 수 있도록

# [How]
- ICounterDevice: SetEncoderMode, SetCounterValue, GetCounterValue 정의
- EncoderMode: UpDown, AbPhase1x, AbPhase2x, AbPhase4x (uint)