### PR TITLE
Add Reconnected event to ICounterDevice

### DIFF
--- a/ControlBeeAbstract/Devices/ICounterDevice.cs
+++ b/ControlBeeAbstract/Devices/ICounterDevice.cs
@@ -7,4 +7,5 @@ public interface ICounterDevice : IDevice
     void SetEncoderMode(int channel, EncoderMode mode);
     void SetCounterValue(int channel, double value);
     double GetCounterValue(int channel);
+    event EventHandler? Reconnected;
 }


### PR DESCRIPTION
# What
ICounterDevice에 event EventHandler? Reconnected 추가

# Why
디바이스 재연결 시 Counter 캐시를 갱신할 수단이 없었음

# How
IDigitalIoDevice의 기존 패턴을 따름