### PR TITLE
Add CancelTrigger to IVisionDevice interface

### DIFF
--- a/ControlBeeAbstract/Devices/IVisionDevice.cs
+++ b/ControlBeeAbstract/Devices/IVisionDevice.cs
@@ -23,7 +23,7 @@ public interface IVisionDevice : IDevice
     void LoadRecipe(string recipeName);
     void SaveRecipe(string? recipeName);
     void SaveImage(int channel, string savePath, string? triggerId);
-    void CancelTrigger(int channel, int inspectionIndex);
+    void CancelTrigger(int channel);
     void SetLightOnOff(int channel, int inspectionIndex, bool on);
     void SetLightValue(int channel, int inspectionIndex, int lightChannel, double value);
     void SetResolution(int channel, double resolution);

--- a/ControlBeeAbstract/Devices/IVisionDevice.cs
+++ b/ControlBeeAbstract/Devices/IVisionDevice.cs
@@ -23,6 +23,7 @@ public interface IVisionDevice : IDevice
     void LoadRecipe(string recipeName);
     void SaveRecipe(string? recipeName);
     void SaveImage(int channel, string savePath, string? triggerId);
+    void CancelTrigger(int channel, int inspectionIndex);
     void SetLightOnOff(int channel, int inspectionIndex, bool on);
     void SetLightValue(int channel, int inspectionIndex, int lightChannel, double value);
     void SetResolution(int channel, double resolution);


### PR DESCRIPTION
# What
- Add `CancelTrigger(channel, inspectionIndex)` to `IVisionDevice`

# Why
- C사 H프로젝트에서 HW Trigger 를 사용하는데, HW Trigger 설정 후 Auto 가 아닌 수동 Rotate 를 하면 불필요한 Trigger 가 발생하여 추가하게 됨
- HW trigger를 취소하는 기능이 없어 상위 레이어에서 호출 불가

# How
- `SetLightOnOff`, `SetResolution`과 동일한 channel 기반 시그니처로 추가